### PR TITLE
Improved item value decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,52 @@ func main() {
 
 See [example/main.go](example/main.go).
 
+## Item Field Values
+
+The values of an item field depend on the type of the field. As such, the type of `Field.Values` is `interface{}` and must be coerced to access. The mapping from field types to values are as follows:
+
+- `app`: `[]AppValue`
+- `date`: `[]DateValue`
+- `text`: `[]TextValue`
+- `number`: `[]NumberValue`
+- `image`: `[]ImageValue`
+- `member`: `[]MemberValue`
+- `contact`: `[]ContactValue`
+- `money`: `[]MoneyValue`
+- `progress`: `[]ProgressValue`
+- `location`: `[]LocationValue`
+- `video`: `[]VideoValue`
+- `duration`: `[]DurationValue`
+- `embed`: `[]EmbedValue`
+- `question`: `[]QuestionValue`
+- `category`: `[]CategoryValue`
+- `tel`: `[]TelValue`
+- `calculation`: `[]CalculationValue`
+
+Coercing `Field.Values` safely can be done with a `switch` on `Field.Type` using the above mapping, or a type switch on `Field.Values`:
+
+```go
+// Example 1
+switch field.Type {
+case "app":
+  for _, appVal := range field.Values.([]AppValue) {
+    fmt.Println(appVal.Value.AppItemId)
+  }
+case "date":
+  // etc
+}
+
+// Example 2
+switch values := field.Values {
+case []AppValue:
+	for _, appVal := range values {
+		fmt.Println(values[0].Value.AppItemId)
+	}
+case []DateValue:
+  // etc
+}
+```
+
 ## Status
 
 - The client supports authentication with username and password (see [Username and Password flow](https://developers.podio.com/authentication/username_password)), app authentication (see [App authentication flow](https://developers.podio.com/authentication/app_auth)) and server-side flow (see [Server-side flow](https://developers.podio.com/authentication/server_side)).

--- a/app.go
+++ b/app.go
@@ -3,7 +3,7 @@ package podio
 import "fmt"
 
 type App struct {
-	Id              int    `json:"app_id"`
+	Id              int64  `json:"app_id"`
 	Name            string `json:"name"`
 	Status          string `json:"status"`
 	DefaultViewId   int    `json:"default_view_id"`
@@ -19,19 +19,19 @@ type App struct {
 	Icon            string `json:"icon"`
 }
 
-func (client *Client) GetApps(spaceId int) (apps []App, err error) {
+func (client *Client) GetApps(spaceId int64) (apps []App, err error) {
 	path := fmt.Sprintf("/app/space/%d?view=micro", spaceId)
 	err = client.Request("GET", path, nil, nil, &apps)
 	return
 }
 
-func (client *Client) GetApp(id int) (app *App, err error) {
+func (client *Client) GetApp(id int64) (app *App, err error) {
 	path := fmt.Sprintf("/app/%d?view=micro", id)
 	err = client.Request("GET", path, nil, nil, &app)
 	return
 }
 
-func (client *Client) GetAppBySpaceIdAndSlug(spaceId int, slug string) (app *App, err error) {
+func (client *Client) GetAppBySpaceIdAndSlug(spaceId int64, slug string) (app *App, err error) {
 	path := fmt.Sprintf("/app/space/%d/%s", spaceId, slug)
 	err = client.Request("GET", path, nil, nil, &app)
 	return

--- a/app.go
+++ b/app.go
@@ -3,24 +3,36 @@ package podio
 import "fmt"
 
 type App struct {
-	Id   uint   `json:"app_id"`
-	Name string `json:"name"`
+	Id              int    `json:"app_id"`
+	Name            string `json:"name"`
+	Status          string `json:"status"`
+	DefaultViewId   int    `json:"default_view_id"`
+	URLAdd          string `json:"url_add"`
+	IconId          int    `json:"icon_id"`
+	LinkAdd         string `json:"link_add"`
+	CurrentRevision int    `json:"current_revision"`
+	ItemName        string `json:"item_name"`
+	Link            string `json:"link"`
+	URL             string `json:"url"`
+	URLLabel        string `json:"url_label"`
+	SpaceId         int    `json:"space_id"`
+	Icon            string `json:"icon"`
 }
 
-func (client *Client) GetApps(space_id uint) (apps []App, err error) {
-	path := fmt.Sprintf("/app/space/%d?view=micro", space_id)
+func (client *Client) GetApps(spaceId int) (apps []App, err error) {
+	path := fmt.Sprintf("/app/space/%d?view=micro", spaceId)
 	err = client.Request("GET", path, nil, nil, &apps)
 	return
 }
 
-func (client *Client) GetApp(id uint) (app *App, err error) {
+func (client *Client) GetApp(id int) (app *App, err error) {
 	path := fmt.Sprintf("/app/%d?view=micro", id)
 	err = client.Request("GET", path, nil, nil, &app)
 	return
 }
 
-func (client *Client) GetAppBySpaceIdAndSlug(space_id uint, slug string) (app *App, err error) {
-	path := fmt.Sprintf("/app/space/%d/%s", space_id, slug)
+func (client *Client) GetAppBySpaceIdAndSlug(spaceId int, slug string) (app *App, err error) {
+	path := fmt.Sprintf("/app/space/%d/%s", spaceId, slug)
 	err = client.Request("GET", path, nil, nil, &app)
 	return
 }

--- a/auth.go
+++ b/auth.go
@@ -30,7 +30,7 @@ func AuthWithUserCredentials(clientId string, clientSecret string, username stri
 	return authRequest(data)
 }
 
-func AuthWithAppCredentials(clientId, clientSecret string, appId uint, appToken string) (*AuthToken, error) {
+func AuthWithAppCredentials(clientId, clientSecret string, appId int, appToken string) (*AuthToken, error) {
 	data := url.Values{
 		"grant_type":    {"app"},
 		"app_id":        {fmt.Sprintf("%d", appId)},

--- a/auth.go
+++ b/auth.go
@@ -30,7 +30,7 @@ func AuthWithUserCredentials(clientId string, clientSecret string, username stri
 	return authRequest(data)
 }
 
-func AuthWithAppCredentials(clientId, clientSecret string, appId int, appToken string) (*AuthToken, error) {
+func AuthWithAppCredentials(clientId, clientSecret string, appId int64, appToken string) (*AuthToken, error) {
 	data := url.Values{
 		"grant_type":    {"app"},
 		"app_id":        {fmt.Sprintf("%d", appId)},

--- a/byline.go
+++ b/byline.go
@@ -2,12 +2,12 @@ package podio
 
 // ByLine describes the creator of a Podio object
 type ByLine struct {
-	Id         uint   `json:"id"`
+	Id         int    `json:"id"`
 	Type       string `json:"type"`
 	Name       string `json:"name"`
 	URL        string `json:"url"`
 	AvatarType string `json:"avatar_type"`
-	AvatarId   uint   `json:"avatar_id"`
+	AvatarId   int    `json:"avatar_id"`
 	Image      File   `json:"image"`
 	LastSeenOn Time   `json:"last_seen_on"`
 
@@ -16,7 +16,7 @@ type ByLine struct {
 
 // Via describes the source of a Podio object
 type Via struct {
-	Id      uint   `json:"id"`
+	Id      int    `json:"id"`
 	Name    string `json:"name"`
 	URL     string `json:"url"`
 	Display bool   `json:"display"`

--- a/byline.go
+++ b/byline.go
@@ -2,7 +2,7 @@ package podio
 
 // ByLine describes the creator of a Podio object
 type ByLine struct {
-	Id         int    `json:"id"`
+	Id         int64  `json:"id"`
 	Type       string `json:"type"`
 	Name       string `json:"name"`
 	URL        string `json:"url"`
@@ -16,7 +16,7 @@ type ByLine struct {
 
 // Via describes the source of a Podio object
 type Via struct {
-	Id      int    `json:"id"`
+	Id      int64  `json:"id"`
 	Name    string `json:"name"`
 	URL     string `json:"url"`
 	Display bool   `json:"display"`

--- a/client.go
+++ b/client.go
@@ -70,10 +70,7 @@ func (client *Client) Request(method string, path string, headers map[string]str
 	}
 
 	if out != nil {
-		err = json.Unmarshal(respBody, out)
-		if err != nil {
-			return err
-		}
+		return json.Unmarshal(respBody, out)
 	}
 
 	return nil

--- a/comment.go
+++ b/comment.go
@@ -5,7 +5,7 @@ import "fmt"
 // Comment is a comment on an object in podio.
 // The object to which this comment is associated is described in this Reference.
 type Comment struct {
-	Id         int        `json:"comment_id"`
+	Id         int64      `json:"comment_id"`
 	ExternalId string     `json:"external_id"`
 	Value      string     `json:"value"`
 	Ref        *Reference `json:"ref"`
@@ -22,7 +22,7 @@ type Comment struct {
 // refType (item, task, ...) and refId identifies the podio object to which the comment is added.
 // text is the actual comment value.
 // Additional parameters can be set in the params map.
-func (client *Client) Comment(refType string, refId int, text string, params map[string]interface{}) (*Comment, error) {
+func (client *Client) Comment(refType string, refId int64, text string, params map[string]interface{}) (*Comment, error) {
 	path := fmt.Sprintf("/comment/%s/%d/", refType, refId)
 	if params == nil {
 		params = map[string]interface{}{}
@@ -38,7 +38,7 @@ func (client *Client) Comment(refType string, refId int, text string, params map
 //
 // refType is the type of the podio object. For legal type values see
 // refId is the podio id of the podio object.
-func (client *Client) GetComments(refType string, refId int) (comments []*Comment, err error) {
+func (client *Client) GetComments(refType string, refId int64) (comments []*Comment, err error) {
 	path := fmt.Sprintf("/comment/%s/%d/", refType, refId)
 	err = client.Request("GET", path, nil, nil, &comments)
 	return

--- a/comment.go
+++ b/comment.go
@@ -5,7 +5,7 @@ import "fmt"
 // Comment is a comment on an object in podio.
 // The object to which this comment is associated is described in this Reference.
 type Comment struct {
-	Id         uint       `json:"comment_id"`
+	Id         int        `json:"comment_id"`
 	ExternalId string     `json:"external_id"`
 	Value      string     `json:"value"`
 	Ref        *Reference `json:"ref"`
@@ -22,7 +22,7 @@ type Comment struct {
 // refType (item, task, ...) and refId identifies the podio object to which the comment is added.
 // text is the actual comment value.
 // Additional parameters can be set in the params map.
-func (client *Client) Comment(refType string, refId uint, text string, params map[string]interface{}) (*Comment, error) {
+func (client *Client) Comment(refType string, refId int, text string, params map[string]interface{}) (*Comment, error) {
 	path := fmt.Sprintf("/comment/%s/%d/", refType, refId)
 	if params == nil {
 		params = map[string]interface{}{}
@@ -38,7 +38,7 @@ func (client *Client) Comment(refType string, refId uint, text string, params ma
 //
 // refType is the type of the podio object. For legal type values see
 // refId is the podio id of the podio object.
-func (client *Client) GetComments(refType string, refId uint) (comments []*Comment, err error) {
+func (client *Client) GetComments(refType string, refId int) (comments []*Comment, err error) {
 	path := fmt.Sprintf("/comment/%s/%d/", refType, refId)
 	err = client.Request("GET", path, nil, nil, &comments)
 	return

--- a/contact.go
+++ b/contact.go
@@ -1,0 +1,15 @@
+package podio
+
+// Contact describes a Podio contact object
+type Contact struct {
+	UserId     int    `json:"user_id"`
+	SpaceId    int    `json:"space_id"`
+	Type       string `json:"type"`
+	Image      File   `json:"image"`
+	ProfileId  int    `json:"profile_id"`
+	OrgId      int    `json:"org_id"`
+	Link       string `json:"link"`
+	Avatar     int    `json:"avatar"`
+	LastSeenOn *Time  `json:"last_seen_on"`
+	Name       string `json:"name"`
+}

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,16 @@
+package podio
+
+// Embed describes a Podio embed object
+type Embed struct {
+	Id          int    `json:"embed_id"`
+	Type        string `json:"type"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	EmbedHTML   string `json:"embed_html"`
+	URL         string `json:"url"`
+	OriginalURL string `json:"original_url"`
+	ResolvedURL string `json:"resolved_url"`
+	Hostname    string `json:"hostname"`
+	EmbedHeight int    `json:"embed_height"`
+	EmbedWidth  int    `json:"embed_width"`
+}

--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 )
 
 type File struct {
-	Id   uint   `json:"file_id"`
+	Id   int    `json:"file_id"`
 	Name string `json:"name"`
 	Link string `json:"link"`
 	Size int    `json:"size"`
@@ -20,7 +20,7 @@ func (client *Client) GetFiles() (files []File, err error) {
 	return
 }
 
-func (client *Client) GetFile(file_id uint) (file *File, err error) {
+func (client *Client) GetFile(file_id int) (file *File, err error) {
 	err = client.Request("GET", fmt.Sprintf("/file/%d", file_id), nil, nil, &file)
 	return
 }
@@ -75,7 +75,7 @@ func (client *Client) CreateFile(name string, contents []byte) (file *File, err 
 	return
 }
 
-func (client *Client) ReplaceFile(oldFileId, newFileId uint) error {
+func (client *Client) ReplaceFile(oldFileId, newFileId int) error {
 	path := fmt.Sprintf("/file/%d/replace", newFileId)
 	params := map[string]interface{}{
 		"old_file_id": oldFileId,
@@ -84,7 +84,7 @@ func (client *Client) ReplaceFile(oldFileId, newFileId uint) error {
 	return client.RequestWithParams("POST", path, nil, params, nil)
 }
 
-func (client *Client) AttachFile(fileId uint, refType string, refId uint) error {
+func (client *Client) AttachFile(fileId int, refType string, refId int) error {
 	path := fmt.Sprintf("/file/%d/attach", fileId)
 	params := map[string]interface{}{
 		"ref_type": refType,
@@ -94,7 +94,7 @@ func (client *Client) AttachFile(fileId uint, refType string, refId uint) error 
 	return client.RequestWithParams("POST", path, nil, params, nil)
 }
 
-func (client *Client) DeleteFile(fileId uint) error {
+func (client *Client) DeleteFile(fileId int) error {
 	path := fmt.Sprintf("/file/%d", fileId)
 	return client.Request("DELETE", path, nil, nil, nil)
 }

--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 )
 
 type File struct {
-	Id   int    `json:"file_id"`
+	Id   int64  `json:"file_id"`
 	Name string `json:"name"`
 	Link string `json:"link"`
 	Size int    `json:"size"`
@@ -20,8 +20,8 @@ func (client *Client) GetFiles() (files []File, err error) {
 	return
 }
 
-func (client *Client) GetFile(file_id int) (file *File, err error) {
-	err = client.Request("GET", fmt.Sprintf("/file/%d", file_id), nil, nil, &file)
+func (client *Client) GetFile(fileId int) (file *File, err error) {
+	err = client.Request("GET", fmt.Sprintf("/file/%d", fileId), nil, nil, &file)
 	return
 }
 

--- a/item.go
+++ b/item.go
@@ -1,7 +1,12 @@
 package podio
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
 
+// Item describes a Podio item object
 type Item struct {
 	Id                 uint     `json:"item_id"`
 	AppItemId          uint     `json:"app_item_id"`
@@ -9,19 +14,186 @@ type Item struct {
 	Title              string   `json:"title"`
 	Files              []*File  `json:"files"`
 	Fields             []*Field `json:"fields"`
+	Space              Space    `json:"space"`
+	App                App      `json:"app"`
+	CreatedVia         Via      `json:"created_via"`
+	CreatedBy          ByLine   `json:"by_line"`
+	CreatedOn          Time     `json:"created_on"`
+	Link               string   `json:"link"`
+	ItemId             uint     `json:"item_id"`
+	Revision           int      `json:"revision"`
 }
 
+// partialField is used for JSON unmarshalling
+type partialField struct {
+	Id         uint            `json:"field_id"`
+	ExternalId string          `json:"external_id"`
+	Type       string          `json:"type"`
+	Label      string          `json:"label"`
+	ValuesJSON json.RawMessage `json:"values"`
+}
+
+// Field describes a Podio field object
 type Field struct {
-	FieldId    uint     `json:"field_id"`
-	ExternalId string   `json:"external_id"`
-	Type       string   `json:"type"`
-	Label      string   `json:"label"`
-	Values     []*Value `json:"values"`
+	partialField
+	Values interface{}
 }
 
-type Value struct {
-	Value interface{} `json:"value"`
+func (f *Field) UnmarshalJSON(data []byte) error {
+	pField := partialField{}
+	if err := json.Unmarshal(data, &pField); err != nil {
+		return err
+	}
+
+	switch pField.Type {
+	case "app":
+		f.Values = []AppValue{}
+	case "date":
+		f.Values = []DateValue{}
+	case "text":
+		f.Values = []TextValue{}
+	case "number":
+		f.Values = []NumberValue{}
+	case "image":
+		f.Values = []ImageValue{}
+	case "member":
+		f.Values = []MemberValue{}
+	case "contact":
+		f.Values = []ContactValue{}
+	case "money":
+		f.Values = []MoneyValue{}
+	case "progress":
+		f.Values = []ProgressValue{}
+	case "location":
+		f.Values = []LocationValue{}
+	case "video":
+		f.Values = []VideoValue{}
+	case "duration":
+		f.Values = []DurationValue{}
+	case "embed":
+		f.Values = []EmbedValue{}
+	case "question":
+		f.Values = []QuestionValue{}
+	case "category":
+		f.Values = []CategoryValue{}
+	case "tel":
+		f.Values = []TelValue{}
+	case "calculation":
+		f.Values = []CalculationValue{}
+	default:
+		// Unknown field type
+		f.Values = []interface{}{}
+	}
+
+	if err := json.Unmarshal(pField.ValuesJSON, &f.Values); err != nil {
+		return fmt.Errorf("[ERR] Cannot unmarshal %s into %s: %v\n", string(pField.ValuesJSON), reflect.TypeOf(f.Values), err)
+	}
+
+	pField.ValuesJSON = nil
+	f.partialField = pField
+	return nil
 }
+
+// TextValue is the value for fields of type `text`
+type TextValue struct {
+	Value string `json:"value"`
+}
+
+// NumberValue is the value for fields of type `number`
+type NumberValue struct {
+	Value float64 `json:"value,string"`
+}
+
+// Image is the value for fields of type `image`
+type ImageValue struct {
+	Value File `json:"value"`
+}
+
+// DateValue is the value for fields of type `date`
+type DateValue struct {
+	Start *Time `json:"start"`
+	End   *Time `json:"end"`
+}
+
+// AppValue is the value for fields of type `app`
+type AppValue struct {
+	Value Item `json:"value"`
+}
+
+// MemberValue is the value for fields of type `member`
+type MemberValue struct {
+	Value int `json:"value"`
+}
+
+// ContactValue is the value for fields of type `contact`
+type ContactValue struct {
+	Value Contact `json:"value"`
+}
+
+// MoneyValue is the value for fields of type `money`
+type MoneyValue struct {
+	Value    float64 `json:"value,string"`
+	Currency string  `json:"currency"`
+}
+
+// ProgressValue is the value for fields of type `progress`
+type ProgressValue struct {
+	Value int `json:"value"`
+}
+
+// LocationValue is the value for fields of type `location`
+type LocationValue struct {
+	Value        string `json:"value"`
+	Formatted    string `json:"formatted"`
+	StreetNumber string `json:"street_number"`
+	StreetName   string `json:"street_name"`
+	PostalCode   string `json:"postal_code"`
+	City         string `json:"city"`
+	State        string `json:"state"`
+	Country      string `json:"country"`
+	Lat          string `json:"lat"`
+	Lng          string `json:"lng"`
+}
+
+// VideoValue is the value for fields of type `video`
+type VideoValue struct {
+	Value int `json:"value"`
+}
+
+// DurationValue is the value for fields of type `duration`
+type DurationValue struct {
+	Value int `json:"value"`
+}
+
+// EmbedValue is the value for fields of type `embed`
+type EmbedValue struct {
+	Embed Embed `json:"embed"`
+	File  File  `json:"file"`
+}
+
+// CategoryValue is the value for fields of type `category`
+type CategoryValue struct {
+	Value struct {
+		Status string `json:"status"`
+		Text   string `json:"text"`
+		Id     int    `json:"id"`
+		Color  string `json:"color"`
+	} `json:"value"`
+}
+
+// QuestionValue is the value for fields of type `question`
+type QuestionValue struct {
+	Value int `json:"value"`
+}
+
+// TelValue is the value for fields of type `tel`
+type TelValue struct {
+	Value int    `json:"value"`
+	URI   string `json:"uri"`
+}
+
+// CalcationValue is the value for fields of type `calculation` (currently untyped)
+type CalculationValue map[string]interface{}
 
 type ItemList struct {
 	Filtered uint    `json:"filtered"`

--- a/item.go
+++ b/item.go
@@ -8,8 +8,8 @@ import (
 
 // Item describes a Podio item object
 type Item struct {
-	Id                 uint     `json:"item_id"`
-	AppItemId          uint     `json:"app_item_id"`
+	Id                 int      `json:"item_id"`
+	AppItemId          int      `json:"app_item_id"`
 	FormattedAppItemId string   `json:"app_item_id_formatted"`
 	Title              string   `json:"title"`
 	Files              []*File  `json:"files"`
@@ -20,7 +20,7 @@ type Item struct {
 	CreatedBy          ByLine   `json:"by_line"`
 	CreatedOn          Time     `json:"created_on"`
 	Link               string   `json:"link"`
-	ItemId             uint     `json:"item_id"`
+	ItemId             int      `json:"item_id"`
 	Revision           int      `json:"revision"`
 }
 
@@ -196,54 +196,54 @@ type TelValue struct {
 type CalculationValue map[string]interface{}
 
 type ItemList struct {
-	Filtered uint    `json:"filtered"`
-	Total    uint    `json:"total"`
+	Filtered int     `json:"filtered"`
+	Total    int     `json:"total"`
 	Items    []*Item `json:"items"`
 }
 
-func (client *Client) GetItems(app_id uint) (items *ItemList, err error) {
-	path := fmt.Sprintf("/item/app/%d/filter?fields=items.fields(files)", app_id)
+func (client *Client) GetItems(appId int) (items *ItemList, err error) {
+	path := fmt.Sprintf("/item/app/%d/filter?fields=items.fields(files)", appId)
 	err = client.Request("POST", path, nil, nil, &items)
 	return
 }
 
-func (client *Client) GetItemByAppItemId(app_id uint, formatted_app_item_id string) (item *Item, err error) {
-	path := fmt.Sprintf("/app/%d/item/%s", app_id, formatted_app_item_id)
+func (client *Client) GetItemByAppItemId(appId int, formattedAppItemId string) (item *Item, err error) {
+	path := fmt.Sprintf("/app/%d/item/%s", appId, formattedAppItemId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
-func (client *Client) GetItemByExternalID(app_id uint, external_id string) (item *Item, err error) {
-	path := fmt.Sprintf("/item/app/%d/external_id/%s", app_id, external_id)
+func (client *Client) GetItemByExternalID(appId int, externalId string) (item *Item, err error) {
+	path := fmt.Sprintf("/item/app/%d/external_id/%s", appId, externalId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
-func (client *Client) GetItem(item_id uint) (item *Item, err error) {
+func (client *Client) GetItem(item_id int) (item *Item, err error) {
 	path := fmt.Sprintf("/item/%d?fields=files", item_id)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
-func (client *Client) CreateItem(app_id uint, external_id string, fieldValues map[string]interface{}) (uint, error) {
-	path := fmt.Sprintf("/item/app/%d", app_id)
+func (client *Client) CreateItem(appId int, externalId string, fieldValues map[string]interface{}) (int, error) {
+	path := fmt.Sprintf("/item/app/%d", appId)
 	params := map[string]interface{}{
 		"fields": fieldValues,
 	}
 
-	if external_id != "" {
-		params["external_id"] = external_id
+	if externalId != "" {
+		params["external_id"] = externalId
 	}
 
 	rsp := &struct {
-		ItemId uint `json:"item_id"`
+		ItemId int `json:"item_id"`
 	}{}
 	err := client.RequestWithParams("POST", path, nil, params, rsp)
 
 	return rsp.ItemId, err
 }
 
-func (client *Client) UpdateItem(itemId uint, fieldValues map[string]interface{}) error {
+func (client *Client) UpdateItem(itemId int, fieldValues map[string]interface{}) error {
 	path := fmt.Sprintf("/item/%d", itemId)
 	params := map[string]interface{}{
 		"fields": fieldValues,

--- a/item.go
+++ b/item.go
@@ -8,7 +8,7 @@ import (
 
 // Item describes a Podio item object
 type Item struct {
-	Id                 int      `json:"item_id"`
+	Id                 int64    `json:"item_id"`
 	AppItemId          int      `json:"app_item_id"`
 	FormattedAppItemId string   `json:"app_item_id_formatted"`
 	Title              string   `json:"title"`
@@ -20,13 +20,12 @@ type Item struct {
 	CreatedBy          ByLine   `json:"by_line"`
 	CreatedOn          Time     `json:"created_on"`
 	Link               string   `json:"link"`
-	ItemId             int      `json:"item_id"`
 	Revision           int      `json:"revision"`
 }
 
 // partialField is used for JSON unmarshalling
 type partialField struct {
-	Id         uint            `json:"field_id"`
+	Id         int64           `json:"field_id"`
 	ExternalId string          `json:"external_id"`
 	Type       string          `json:"type"`
 	Label      string          `json:"label"`
@@ -201,31 +200,31 @@ type ItemList struct {
 	Items    []*Item `json:"items"`
 }
 
-func (client *Client) GetItems(appId int) (items *ItemList, err error) {
+func (client *Client) GetItems(appId int64) (items *ItemList, err error) {
 	path := fmt.Sprintf("/item/app/%d/filter?fields=items.fields(files)", appId)
 	err = client.Request("POST", path, nil, nil, &items)
 	return
 }
 
-func (client *Client) GetItemByAppItemId(appId int, formattedAppItemId string) (item *Item, err error) {
+func (client *Client) GetItemByAppItemId(appId int64, formattedAppItemId string) (item *Item, err error) {
 	path := fmt.Sprintf("/app/%d/item/%s", appId, formattedAppItemId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
-func (client *Client) GetItemByExternalID(appId int, externalId string) (item *Item, err error) {
+func (client *Client) GetItemByExternalID(appId int64, externalId string) (item *Item, err error) {
 	path := fmt.Sprintf("/item/app/%d/external_id/%s", appId, externalId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
-func (client *Client) GetItem(item_id int) (item *Item, err error) {
-	path := fmt.Sprintf("/item/%d?fields=files", item_id)
+func (client *Client) GetItem(itemId int64) (item *Item, err error) {
+	path := fmt.Sprintf("/item/%d?fields=files", itemId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
-func (client *Client) CreateItem(appId int, externalId string, fieldValues map[string]interface{}) (int, error) {
+func (client *Client) CreateItem(appId int, externalId string, fieldValues map[string]interface{}) (int64, error) {
 	path := fmt.Sprintf("/item/app/%d", appId)
 	params := map[string]interface{}{
 		"fields": fieldValues,
@@ -236,7 +235,7 @@ func (client *Client) CreateItem(appId int, externalId string, fieldValues map[s
 	}
 
 	rsp := &struct {
-		ItemId int `json:"item_id"`
+		ItemId int64 `json:"item_id"`
 	}{}
 	err := client.RequestWithParams("POST", path, nil, params, rsp)
 

--- a/org.go
+++ b/org.go
@@ -3,7 +3,7 @@ package podio
 import "fmt"
 
 type Organization struct {
-	Id   uint   `json:"org_id"`
+	Id   int    `json:"org_id"`
 	Slug string `json:"url_label"`
 	Name string `json:"name"`
 }
@@ -13,7 +13,7 @@ func (client *Client) GetOrganizations() (orgs []Organization, err error) {
 	return
 }
 
-func (client *Client) GetOrganization(id uint) (org *Organization, err error) {
+func (client *Client) GetOrganization(id int) (org *Organization, err error) {
 	path := fmt.Sprintf("/org/%d", id)
 	err = client.Request("GET", path, nil, nil, &org)
 	return

--- a/org.go
+++ b/org.go
@@ -3,7 +3,7 @@ package podio
 import "fmt"
 
 type Organization struct {
-	Id   int    `json:"org_id"`
+	Id   int64  `json:"org_id"`
 	Slug string `json:"url_label"`
 	Name string `json:"name"`
 }
@@ -13,7 +13,7 @@ func (client *Client) GetOrganizations() (orgs []Organization, err error) {
 	return
 }
 
-func (client *Client) GetOrganization(id int) (org *Organization, err error) {
+func (client *Client) GetOrganization(id int64) (org *Organization, err error) {
 	path := fmt.Sprintf("/org/%d", id)
 	err = client.Request("GET", path, nil, nil, &org)
 	return

--- a/reference.go
+++ b/reference.go
@@ -2,7 +2,7 @@ package podio
 
 // Reference is a reference to from one object to another Podio object
 type Reference struct {
-	Id       uint                   `json:"id"`
+	Id       int                    `json:"id"`
 	Type     string                 `json:"type"`
 	TypeName string                 `json:"type_name"`
 	Title    string                 `json:"title"`

--- a/space.go
+++ b/space.go
@@ -3,27 +3,27 @@ package podio
 import "fmt"
 
 type Space struct {
-	Id       int    `json:"space_id"`
+	Id       int64  `json:"space_id"`
 	Slug     string `json:"url_label"`
 	Name     string `json:"name"`
 	URL      string `json:"url"`
 	URLLabel string `json:"url_label"`
-	OrgId    int    `json:"org_id"`
+	OrgId    int64  `json:"org_id"`
 }
 
-func (client *Client) GetSpaces(orgId int) (spaces []Space, err error) {
+func (client *Client) GetSpaces(orgId int64) (spaces []Space, err error) {
 	path := fmt.Sprintf("/org/%d/space", orgId)
 	err = client.Request("GET", path, nil, nil, &spaces)
 	return
 }
 
-func (client *Client) GetSpace(id int) (space *Space, err error) {
+func (client *Client) GetSpace(id int64) (space *Space, err error) {
 	path := fmt.Sprintf("/space/%d", id)
 	err = client.Request("GET", path, nil, nil, &space)
 	return
 }
 
-func (client *Client) GetSpaceByOrgIdAndSlug(orgId int, slug string) (space *Space, err error) {
+func (client *Client) GetSpaceByOrgIdAndSlug(orgId int64, slug string) (space *Space, err error) {
 	path := fmt.Sprintf("/space/org/%d/%s", orgId, slug)
 	err = client.Request("GET", path, nil, nil, &space)
 	return

--- a/space.go
+++ b/space.go
@@ -3,25 +3,28 @@ package podio
 import "fmt"
 
 type Space struct {
-	Id   uint   `json:"space_id"`
-	Slug string `json:"url_label"`
-	Name string `json:"name"`
+	Id       int    `json:"space_id"`
+	Slug     string `json:"url_label"`
+	Name     string `json:"name"`
+	URL      string `json:"url"`
+	URLLabel string `json:"url_label"`
+	OrgId    int    `json:"org_id"`
 }
 
-func (client *Client) GetSpaces(org_id uint) (spaces []Space, err error) {
-	path := fmt.Sprintf("/org/%d/space", org_id)
+func (client *Client) GetSpaces(orgId int) (spaces []Space, err error) {
+	path := fmt.Sprintf("/org/%d/space", orgId)
 	err = client.Request("GET", path, nil, nil, &spaces)
 	return
 }
 
-func (client *Client) GetSpace(id uint) (space *Space, err error) {
+func (client *Client) GetSpace(id int) (space *Space, err error) {
 	path := fmt.Sprintf("/space/%d", id)
 	err = client.Request("GET", path, nil, nil, &space)
 	return
 }
 
-func (client *Client) GetSpaceByOrgIdAndSlug(org_id uint, slug string) (space *Space, err error) {
-	path := fmt.Sprintf("/space/org/%d/%s", org_id, slug)
+func (client *Client) GetSpaceByOrgIdAndSlug(orgId int, slug string) (space *Space, err error) {
+	path := fmt.Sprintf("/space/org/%d/%s", orgId, slug)
 	err = client.Request("GET", path, nil, nil, &space)
 	return
 }


### PR DESCRIPTION
Prior to this PR, item values decoding just used `map[string]interface{}` causing some annoying issues (see #5). This PR actually decodes values in properly types structs, such that JSON decoding is done correctly, e.g. dates are properly parsed.

The values of an item field depend on the type of the field. As such, the type of `Field.Values` is `interface{}` and must be coerced to access. The mapping from field types to values are as follows:

- `app`: `[]AppValue`
- `date`: `[]DateValue`
- `text`: `[]TextValue`
- `number`: `[]NumberValue`
- `image`: `[]ImageValue`
- `member`: `[]MemberValue`
- `contact`: `[]ContactValue`
- `money`: `[]MoneyValue`
- `progress`: `[]ProgressValue`
- `location`: `[]LocationValue`
- `video`: `[]VideoValue`
- `duration`: `[]DurationValue`
- `embed`: `[]EmbedValue`
- `question`: `[]QuestionValue`
- `category`: `[]CategoryValue`
- `tel`: `[]TelValue`
- `calculation`: `[]CalculationValue`

Coercing `Field.Values` safely can be done with a `switch` on `Field.Type` using the above mapping, or a type switch on `Field.Values`:

```go
// Example 1
switch field.Type {
case "app":
  for _, appVal := range field.Values.([]AppValue) {
    fmt.Println(appVal.Value.AppItemId)
  }
case "date":
  // etc
}

// Example 2
switch values := field.Values {
case []AppValue:
	for _, appVal := range values {
		fmt.Println(values[0].Value.AppItemId)
	}
case []DateValue:
  // etc
}
```