### PR TITLE
Adding comments that point to the official documentation

### DIFF
--- a/app.go
+++ b/app.go
@@ -19,18 +19,21 @@ type App struct {
 	Icon            string `json:"icon"`
 }
 
+// https://developers.podio.com/doc/applications/get-apps-by-space-22478
 func (client *Client) GetApps(spaceId int64) (apps []App, err error) {
 	path := fmt.Sprintf("/app/space/%d?view=micro", spaceId)
 	err = client.Request("GET", path, nil, nil, &apps)
 	return
 }
 
+// https://developers.podio.com/doc/applications/get-app-22349
 func (client *Client) GetApp(id int64) (app *App, err error) {
 	path := fmt.Sprintf("/app/%d?view=micro", id)
 	err = client.Request("GET", path, nil, nil, &app)
 	return
 }
 
+// https://developers.podio.com/doc/applications/get-app-on-space-by-url-label-477105
 func (client *Client) GetAppBySpaceIdAndSlug(spaceId int64, slug string) (app *App, err error) {
 	path := fmt.Sprintf("/app/space/%d/%s", spaceId, slug)
 	err = client.Request("GET", path, nil, nil, &app)

--- a/file.go
+++ b/file.go
@@ -16,11 +16,13 @@ type File struct {
 	Push Push   `json:"push"`
 }
 
+// https://developers.podio.com/doc/files/get-files-4497983
 func (client *Client) GetFiles() (files []File, err error) {
 	err = client.Request("GET", "/file", nil, nil, &files)
 	return
 }
 
+// https://developers.podio.com/doc/files/get-file-22451
 func (client *Client) GetFile(fileId int) (file *File, err error) {
 	err = client.Request("GET", fmt.Sprintf("/file/%d", fileId), nil, nil, &file)
 	return
@@ -44,6 +46,7 @@ func (client *Client) GetFileContents(url string) ([]byte, error) {
 	return respBody, nil
 }
 
+// https://developers.podio.com/doc/files/upload-file-1004361
 func (client *Client) CreateFile(name string, contents []byte) (file *File, err error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -76,6 +79,7 @@ func (client *Client) CreateFile(name string, contents []byte) (file *File, err 
 	return
 }
 
+// https://developers.podio.com/doc/files/replace-file-22450
 func (client *Client) ReplaceFile(oldFileId, newFileId int) error {
 	path := fmt.Sprintf("/file/%d/replace", newFileId)
 	params := map[string]interface{}{
@@ -85,6 +89,7 @@ func (client *Client) ReplaceFile(oldFileId, newFileId int) error {
 	return client.RequestWithParams("POST", path, nil, params, nil)
 }
 
+// https://developers.podio.com/doc/files/attach-file-22518
 func (client *Client) AttachFile(fileId int, refType string, refId int) error {
 	path := fmt.Sprintf("/file/%d/attach", fileId)
 	params := map[string]interface{}{
@@ -95,6 +100,7 @@ func (client *Client) AttachFile(fileId int, refType string, refId int) error {
 	return client.RequestWithParams("POST", path, nil, params, nil)
 }
 
+// https://developers.podio.com/doc/files/delete-file-22453
 func (client *Client) DeleteFile(fileId int) error {
 	path := fmt.Sprintf("/file/%d", fileId)
 	return client.Request("DELETE", path, nil, nil, nil)

--- a/item.go
+++ b/item.go
@@ -229,7 +229,6 @@ func (client *Client) GetItem(itemId int64) (item *Item, err error) {
 	return
 }
 
-
 // https://developers.podio.com/doc/items/add-new-item-22362
 func (client *Client) CreateItem(appId int, externalId string, fieldValues map[string]interface{}) (int64, error) {
 	path := fmt.Sprintf("/item/app/%d", appId)

--- a/item.go
+++ b/item.go
@@ -201,30 +201,36 @@ type ItemList struct {
 	Items    []*Item `json:"items"`
 }
 
+// https://developers.podio.com/doc/items/filter-items-4496747
 func (client *Client) GetItems(appId int64) (items *ItemList, err error) {
 	path := fmt.Sprintf("/item/app/%d/filter?fields=items.fields(files)", appId)
 	err = client.Request("POST", path, nil, nil, &items)
 	return
 }
 
+// https://developers.podio.com/doc/items/get-item-by-app-item-id-66506688
 func (client *Client) GetItemByAppItemId(appId int64, formattedAppItemId string) (item *Item, err error) {
 	path := fmt.Sprintf("/app/%d/item/%s", appId, formattedAppItemId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
+// https://developers.podio.com/doc/items/get-item-by-external-id-19556702
 func (client *Client) GetItemByExternalID(appId int64, externalId string) (item *Item, err error) {
 	path := fmt.Sprintf("/item/app/%d/external_id/%s", appId, externalId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
+// https://developers.podio.com/doc/items/get-item-22360
 func (client *Client) GetItem(itemId int64) (item *Item, err error) {
 	path := fmt.Sprintf("/item/%d?fields=files", itemId)
 	err = client.Request("GET", path, nil, nil, &item)
 	return
 }
 
+
+// https://developers.podio.com/doc/items/add-new-item-22362
 func (client *Client) CreateItem(appId int, externalId string, fieldValues map[string]interface{}) (int64, error) {
 	path := fmt.Sprintf("/item/app/%d", appId)
 	params := map[string]interface{}{
@@ -243,6 +249,7 @@ func (client *Client) CreateItem(appId int, externalId string, fieldValues map[s
 	return rsp.ItemId, err
 }
 
+// https://developers.podio.com/doc/items/update-item-22363
 func (client *Client) UpdateItem(itemId int, fieldValues map[string]interface{}) error {
 	path := fmt.Sprintf("/item/%d", itemId)
 	params := map[string]interface{}{


### PR DESCRIPTION
In the ruby gem we also have comments indicating where to find the documentation for each API call.

Though it might be handy to have it in go to.

(other files still to do later)