### PR TITLE
Get items with extra parameters and attributes.

### DIFF
--- a/item.go
+++ b/item.go
@@ -209,7 +209,7 @@ func (client *Client) GetItems(appId int64) (items *ItemList, err error) {
 }
 
 // https://developers.podio.com/doc/items/filter-items-4496747
-func (client *Client) filterItems(appId int64, params map[string]interface{}) (items *ItemList, err error) {
+func (client *Client) FilterItems(appId int64, params map[string]interface{}) (items *ItemList, err error) {
 	path := fmt.Sprintf("/item/app/%d/filter?fields=items.fields(files)", appId)
 	err = client.RequestWithParams("POST", path, nil, params, &items)
 	return

--- a/item.go
+++ b/item.go
@@ -208,6 +208,13 @@ func (client *Client) GetItems(appId int64) (items *ItemList, err error) {
 	return
 }
 
+// https://developers.podio.com/doc/items/filter-items-4496747
+func (client *Client) filterItems(appId int64, params map[string]interface{}) (items *ItemList, err error) {
+	path := fmt.Sprintf("/item/app/%d/filter?fields=items.fields(files)", appId)
+	err = client.RequestWithParams("POST", path, nil, params, &items)
+	return
+}
+
 // https://developers.podio.com/doc/items/get-item-by-app-item-id-66506688
 func (client *Client) GetItemByAppItemId(appId int64, formattedAppItemId string) (item *Item, err error) {
 	path := fmt.Sprintf("/app/%d/item/%s", appId, formattedAppItemId)


### PR DESCRIPTION
Allow for filters and attributes E.g. `{filters: {"category-field": [1,4,5]}, "sort_by": "created_on", "sort_desc": false}`

The current `getItems` does not have an extra parameter and I didn't think you wanted to change the params of that method